### PR TITLE
Glossary - initial structure and definitions

### DIFF
--- a/terminology/glossary.md
+++ b/terminology/glossary.md
@@ -1,34 +1,35 @@
 # Glossary
 
-- BBP
-- bug bar
-- CERT
-- CSIRT
-- CNA
-- CVD
-- CVE
-- CVSS
-- CWE
-- disclosure policy
-- finder
-- GHSA ID
-- GSD
-- legal safe harbor
-- maintainer
-- MITRE
-- MPCVD - Multi-Party CVD
-- NDA
-- NIST
-- NVD
-- open source software (OSS) 
-- OSV ID
-- OpenSSF
-- POC
-- PSIRT
-- security policy
-- SIRT
-- Seclist
-- TLP marker
-- VDP
-- VMT
-- vulnerability disclosure
+| Term | Description | Source 1 | Source 2| Source 3|
+|------|-------------|----------|---------|---------|
+|BBP|A Bug Bounty Program is an offering by organizations for individuals to receive recognition and compensation for reporting security related bugs| |||
+|Bug bar|A quality severity threshold for security vulnerabilities which sets the guideline for taking decisions on bugs |[Microsoft](https://learn.microsoft.com/en-us/security/sdl/security-bug-bar-sample)|||
+|CERT|The Computer Emergency Readiness Team is a U.S. based government organization researching and reporting on Internet-related security problems.|[NIST](https://csrc.nist.gov/glossary/term/cert)|||
+|CSIRT| The Cmputer Security Incident Response Team is a group that provides organizations with services and support surrounding the assessment, management and prevention of cybersecurity-related emergencies|[NIST](https://csrc.nist.gov/glossary/term/computer_security_incident_response_team)|||
+|CNA|CVE Naming Authorities are groups authorized by the CVE Program to assign CVE IDs to vulnerabilities and publish CVE Records within their own specific scopes of coverage|[NIST](https://csrc.nist.gov/glossary/term/cna)|[CVE.org](https://www.cve.org/ProgramOrganization/CNAs)|
+|CVD|A Coordinated Vulenrability Disclosure coordinates the remediation and public disclosure of newly identified cybersecurity vulnerabilities||||
+|CVE|Common Vulnerabilities and Exposures is a dictionary of common names for publicly known information system vulnerabilities|[NIST](https://csrc.nist.gov/glossary/term/cve)|||
+|CVSS|Common Vulnerability Scoring System is a framework for communicating the characteristics and severity of software vulnerabilities|[NIST](https://csrc.nist.gov/glossary/term/common_vulnerability_scoring_system)|||
+|CWE|Common Weakness Enumeration is a category system for hardware and software weaknesses and vulnerabilities|[NIST](https://csrc.nist.gov/glossary/term/common_weakness_enumeration)|||
+|Disclosure policy| Provides guidelines for finders on conducting and submitting information on security vulnerabilities||||
+|Finder|||||
+|GHSA ID|||||
+|GSD|||||
+|Legal safe harbor|||||
+|Maintainer|||||
+|MITRE|An American not-for-profit organization supporting various U.S. government agencies in cybersecurity||||
+|MPCVD| A Multi-Party CVD is a coordinated vulenrability disclosure which spans multiple receiving organizations|[NTIA](https://www.ntia.doc.gov/other-publication/2016/multistakeholder-process-cybersecurity-vulnerabilities)|||
+|NDA|A Non-disclosure Agreement is a contract that prohibits the sharing of confidential information||||
+|NIST|The National Institute of Standards and Technology is a U.S. agency that promotes and maintains measurement standards||||
+|NVD|The National Vulnerability Database is a U.S. Government repository of standards-based vulnerability management data|[NIST](https://csrc.nist.gov/glossary/term/nvd)|||
+|OSS| Open Source Software is software with source code that anyone can inspect, modify, and enhance||||
+|OSV ID|||||
+|OpenSSF|The Open Source Security Foundation is a Linux Foundation, cross-industry forum collaborating to improve open source software security|[OSSF](https://openssf.org/about/faq/#)|||
+|POC|||||
+|PSIRT|A Product Security Incident Response Team is responsible for identifying, assessing and remediating risks associated with security vulnerabilities within the products of an organization|[NIST](https://csrc.nist.gov/glossary/term/product_security_incident_response_team)|||
+|Security policy|||||
+|SIRT|||||
+|Seclist|||||
+|TLP marker|||||
+|VDP|A Vulnerability Disclosure Process is a framework for finders of security vulnerabilities to submit findings about product or service to its maintainers||||
+|VMT|||||

--- a/terminology/glossary.md
+++ b/terminology/glossary.md
@@ -2,34 +2,34 @@
 
 | Term | Description | Source 1 | Source 2| Source 3|
 |------|-------------|----------|---------|---------|
-|BBP|A Bug Bounty Program is an offering by organizations for individuals to receive recognition and compensation for reporting security related bugs| |||
-|Bug bar|A quality severity threshold for security vulnerabilities which sets the guideline for taking decisions on bugs |[Microsoft](https://learn.microsoft.com/en-us/security/sdl/security-bug-bar-sample)|||
+|BBP|A Bug Bounty Program is an offering by organizations for individuals to receive recognition and compensation for reporting security related bugs.| |||
+|Bug bar|A bug bar is a threshold for security vulnerabilities which sets the guideline for taking decisions on bugs.|[Stack Exchage](https://softwareengineering.stackexchange.com/questions/232425/what-is-the-process-of-creating-a-bug-bar)|[Microsoft](https://learn.microsoft.com/en-us/security/sdl/security-bug-bar-sample)||
 |CERT|The Computer Emergency Readiness Team is a U.S. based government organization researching and reporting on Internet-related security problems.|[NIST](https://csrc.nist.gov/glossary/term/cert)|||
-|CSIRT| The Cmputer Security Incident Response Team is a group that provides organizations with services and support surrounding the assessment, management and prevention of cybersecurity-related emergencies|[NIST](https://csrc.nist.gov/glossary/term/computer_security_incident_response_team)|||
-|CNA|CVE Naming Authorities are groups authorized by the CVE Program to assign CVE IDs to vulnerabilities and publish CVE Records within their own specific scopes of coverage|[NIST](https://csrc.nist.gov/glossary/term/cna)|[CVE.org](https://www.cve.org/ProgramOrganization/CNAs)|
-|CVD|A Coordinated Vulenrability Disclosure coordinates the remediation and public disclosure of newly identified cybersecurity vulnerabilities||||
-|CVE|Common Vulnerabilities and Exposures is a dictionary of common names for publicly known information system vulnerabilities|[NIST](https://csrc.nist.gov/glossary/term/cve)|||
-|CVSS|Common Vulnerability Scoring System is a framework for communicating the characteristics and severity of software vulnerabilities|[NIST](https://csrc.nist.gov/glossary/term/common_vulnerability_scoring_system)|||
-|CWE|Common Weakness Enumeration is a category system for hardware and software weaknesses and vulnerabilities|[NIST](https://csrc.nist.gov/glossary/term/common_weakness_enumeration)|||
-|Disclosure policy| Provides guidelines for finders on conducting and submitting information on security vulnerabilities||||
+|CSIRT| The Computer Security Incident Response Team is a group that provides organizations with services and support surrounding the assessment, management, and prevention of cybersecurity-related emergencies.|[NIST](https://csrc.nist.gov/glossary/term/computer_security_incident_response_team)|||
+|CNA|CVE Naming Authorities are groups authorized by the CVE Program to assign CVE IDs to vulnerabilities and publish CVE Records within their own specific scopes of coverage.|[NIST](https://csrc.nist.gov/glossary/term/cna)|[CVE.org](https://www.cve.org/ProgramOrganization/CNAs)|
+|CVD|A Coordinated Vulenrability Disclosure coordinates the remediation and public disclosure of newly identified cybersecurity vulnerabilities.|[CISA](https://www.cisa.gov/coordinated-vulnerability-disclosure-process)|||
+|CVE|Common Vulnerabilities and Exposures is a dictionary of common names for publicly known information system vulnerabilities.|[NIST](https://csrc.nist.gov/glossary/term/cve)|||
+|CVSS|A Common Vulnerability Scoring System is a framework for communicating the characteristics and severity of software vulnerabilities.|[NIST](https://csrc.nist.gov/glossary/term/common_vulnerability_scoring_system)|||
+|CWE|Common Weakness Enumeration is a category system for hardware and software weaknesses and vulnerabilities.|[NIST](https://csrc.nist.gov/glossary/term/common_weakness_enumeration)|||
+|Disclosure policy| Vulnerability disclosure is the “act of initially providing vulnerability information to a party that was not believed to be previously aware”.|[CISA](https://www.cisa.gov/binding-operational-directive-20-01#fn:2)|||
 |Finder|||||
 |GHSA ID|||||
 |GSD|||||
 |Legal safe harbor|||||
-|Maintainer|||||
-|MITRE|An American not-for-profit organization supporting various U.S. government agencies in cybersecurity||||
-|MPCVD| A Multi-Party CVD is a coordinated vulenrability disclosure which spans multiple receiving organizations|[NTIA](https://www.ntia.doc.gov/other-publication/2016/multistakeholder-process-cybersecurity-vulnerabilities)|||
-|NDA|A Non-disclosure Agreement is a contract that prohibits the sharing of confidential information||||
-|NIST|The National Institute of Standards and Technology is a U.S. agency that promotes and maintains measurement standards||||
-|NVD|The National Vulnerability Database is a U.S. Government repository of standards-based vulnerability management data|[NIST](https://csrc.nist.gov/glossary/term/nvd)|||
-|OSS| Open Source Software is software with source code that anyone can inspect, modify, and enhance||||
+|Maintainer|In free and open source software and inner source software, a software maintainer or package maintainer is usually one or more people who build source code into a binary package for distribution, commit patches, or organize code in a source repository.|[Wikipedia](https://en.wikipedia.org/wiki/Software_maintainer#:~:text=In%20free%20and%20open%20source,code%20in%20a%20source%20repository)|||
+|MITRE|An American not-for-profit organization supporting various U.S. government agencies in cybersecurity|[MITRE](https://www.mitre.org/who-we-are)|||
+|MPCVD| A Multi-Party CVD is a coordinated vulnerability disclosure which spans multiple receiving organizations.|[NTIA](https://www.ntia.doc.gov/other-publication/2016/multistakeholder-process-cybersecurity-vulnerabilities)|||
+|NDA|A Non-disclosure Agreement is a contract that prohibits the sharing of confidential information.|[Wikipedia](https://en.wikipedia.org/wiki/Non-disclosure_agreement)|||
+|NIST|The National Institute of Standards and Technology is a U.S. agency that promotes and maintains measurement standards.|[NIST](https://www.nist.gov/about-nist)|||
+|NVD|The National Vulnerability Database is a U.S. Government repository of standards-based vulnerability management data.|[NIST](https://csrc.nist.gov/glossary/term/nvd)|||
+|OSS| Open Source Software is a computer software that is released under a license which grants users the rights to use, inspect, modify, enhance, and disrtibute the source code.|[Wikipedia](https://en.wikipedia.org/wiki/Open-source_software)|||
 |OSV ID|||||
-|OpenSSF|The Open Source Security Foundation is a Linux Foundation, cross-industry forum collaborating to improve open source software security|[OSSF](https://openssf.org/about/faq/#)|||
-|POC|||||
-|PSIRT|A Product Security Incident Response Team is responsible for identifying, assessing and remediating risks associated with security vulnerabilities within the products of an organization|[NIST](https://csrc.nist.gov/glossary/term/product_security_incident_response_team)|||
-|Security policy|||||
+|OpenSSF|The Open Source Security Foundation is a Linux Foundation, cross-industry forum collaborating to improve open source software security.|[OSSF](https://openssf.org/about/faq/#)|||
+|POC|In both computer security and encryption, Proof Of Concept refers to a demonstration that in principle shows how a system may be protected or compromised, without the necessity of building a complete working vehicle for that purpose.|[Wikipedia](https://en.wikipedia.org/wiki/Proof_of_concept#Security)|||
+|PSIRT|A Product Security Incident Response Team is responsible for identifying, assessing and remediating risks associated with security vulnerabilities within the products of an organization.|[NIST](https://csrc.nist.gov/glossary/term/product_security_incident_response_team)|||
 |SIRT|||||
-|Seclist|||||
+|Seclist|A Seclist is a collection of multiple types of lists used during security assessments, collected in one place. List types include usernames, passwords, URLs, sensitive data patterns, fuzzing payloads, web shells, and many more.|[OWASP](https://owasp.org/www-project-seclists/migrated_content)|||
+|Security policy|A Security Policy is a set of criteria for the provision of security services.|[NIST](https://csrc.nist.gov/glossary/term/security_policy)|||
 |TLP marker|||||
-|VDP|A Vulnerability Disclosure Process is a framework for finders of security vulnerabilities to submit findings about product or service to its maintainers||||
+|VDP|A Vulnerability Disclosure Process is a framework for finders of security vulnerabilities to submit findings about product or service to its maintainers.||||
 |VMT|||||


### PR DESCRIPTION
This is still WIP, comments are very welcome. specifically interested in getting some feedbacks about:

* Thoughts about the table's structure: columns Source1, Source2, Source3 vs. columns with specific source names (NIST, CVE.org, OWASP, etc.).
* Quite a few NIST definitions are actually empty (for instance https://csrc.nist.gov/glossary/term/cert). should I remove those? 
* What other glossary-sources would be good to quote in additional columns?
*  Some terms I could not find any source for. please comment if you have such source in mind, or would like to propose a definition for, or if it should be perhaps removed. 