### PR TITLE
Notes moved to OpenSSF Google Drive

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ The SIG currently has two initiatives it is caretaking at this time:
 - [2022 Meeting Minutes](https://docs.google.com/document/d/1wuly4bt7zSv4WYsbsr3AlNdq6QOMPCAAt2jtr0PtfQM/edit)
 
 - The Diversity, Equality, and Inclusion (DEI) subcommittee meets every other Tuesday @ 11am EST.  The invite is available on the [OpenSSF Community Calendar](https://calendar.google.com/calendar/u/0/r?cid=czYzdm9lZmhwNWk5cGZsdGI1cTY3bmdwZXNAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ).
-- [DEI Subcommittee Meeting Notes](https://docs.google.com/document/d/1LdQ07veOcJ596Vo3aQZCFy-HHeEO7cHnbE_6u_uq9Fk/edit#)
+- [DEI Subcommittee Meeting Notes](https://docs.google.com/document/d/1Ba_NJWWlsbTn2kVoBFpnMFMmdez9yJrHayocaxKkjaY/edit?usp=sharing)
 
 ## Governance
 

--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ The SIG currently has two initiatives it is caretaking at this time:
 ## Meeting times
 
 - The Full SIG meets every other Wednesday @ 09:00am EST. The invite is available on the [OpenSSF Community Calendar](https://calendar.google.com/calendar/u/0/r?cid=czYzdm9lZmhwNWk5cGZsdGI1cTY3bmdwZXNAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ).
-- [2023 Meeting Minutes](https://docs.google.com/document/d/18GBwvQJNcPnwxKrnp43DhBZC7K1JM0xzGkDoKh5mu8U/edit#heading=h.9m0zi4b0wnne)
-- [2022 Meeting Minutes](https://docs.google.com/document/d/1Lt8uGpiMFfgws8VF36xtTMaJAeHufha-7Dqz1tjrPGY/edit#heading=h.naeeah7jeanr)
+- [2023 Meeting Minutes](https://docs.google.com/document/d/18lIznkQyrcD_KI-7bKhWJQ5bjwdHpdzelA9kPTF1Gow/edit)
+- [2022 Meeting Minutes](https://docs.google.com/document/d/1wuly4bt7zSv4WYsbsr3AlNdq6QOMPCAAt2jtr0PtfQM/edit)
 
 - The Diversity, Equality, and Inclusion (DEI) subcommittee meets every other Tuesday @ 11am EST.  The invite is available on the [OpenSSF Community Calendar](https://calendar.google.com/calendar/u/0/r?cid=czYzdm9lZmhwNWk5cGZsdGI1cTY3bmdwZXNAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ).
 - [DEI Subcommittee Meeting Notes](https://docs.google.com/document/d/1LdQ07veOcJ596Vo3aQZCFy-HHeEO7cHnbE_6u_uq9Fk/edit#)


### PR DESCRIPTION
We are moving all the notes/minutes to the OpennSSF google drive. Some of the old minutes where made with old work accounts that are no longer owned by the people that are participating in the OpenSSF. By migrating them to the [OpenSSF google drive](https://drive.google.com/drive/folders/1r2WeqrBEjehGbSpzGKcTILZdWsD9lYQP?usp=share_link) we will mitigate that issue.